### PR TITLE
Do not check for /dev/arandom any more.

### DIFF
--- a/ERRATA.md
+++ b/ERRATA.md
@@ -4,15 +4,14 @@
 
 The order is:
 
- 1. `fread() /dev/arandom if available`
- 2. `fread() /dev/urandom if available`
- 3. `mcrypt_create_iv($bytes, MCRYPT_CREATE_IV)`
- 4. `COM('CAPICOM.Utilities.1')->GetRandom()`
- 5. `openssl_random_pseudo_bytes()`
+ 1. `fread() /dev/urandom if available`
+ 2. `mcrypt_create_iv($bytes, MCRYPT_CREATE_IV)`
+ 3. `COM('CAPICOM.Utilities.1')->GetRandom()`
+ 4. `openssl_random_pseudo_bytes()`
 
-We read `/dev/arandom` first (if it exists) and `/dev/urandom` second. 
-These are the preferred files to read for random data for cryptographic
-purposes for BSD and Linux (respectively).
+We read `/dev/urandom` first (if it exists).
+This is the preferred file to read for random data for cryptographic
+purposes for BSD and Linux.
 
 Despite [strongly urging people not to use mcrypt in their projects](https://paragonie.com/blog/2015/05/if-you-re-typing-word-mcrypt-into-your-code-you-re-doing-it-wrong),
 because libmcrypt is abandonware and the API puts too much responsibility on the

--- a/lib/random.php
+++ b/lib/random.php
@@ -38,29 +38,20 @@ if (!function_exists('random_bytes')) {
      * to the operating environment. It's a micro-optimization.
      * 
      * In order of preference:
-     *   1. fread() /dev/arandom if available
-     *   2. fread() /dev/urandom if available
-     *   3. mcrypt_create_iv($bytes, MCRYPT_CREATE_IV)
-     *   4. COM('CAPICOM.Utilities.1')->GetRandom()
-     *   5. openssl_random_pseudo_bytes()
+     *   1. fread() /dev/urandom if available
+     *   2. mcrypt_create_iv($bytes, MCRYPT_CREATE_IV)
+     *   3. COM('CAPICOM.Utilities.1')->GetRandom()
+     *   4. openssl_random_pseudo_bytes()
      * 
      * See ERRATA.md for our reasoning behind this particular order
      */
-     if (
-        !ini_get('open_basedir') && 
-        (
-            is_readable('/dev/arandom') || is_readable('/dev/urandom')
-        )
-    ) {
+     if (!ini_get('open_basedir') && is_readable('/dev/urandom')) {
         /**
-         * Unless open_basedir is enabled, use /dev/arandom or /dev/urandom for
+         * Unless open_basedir is enabled, use /dev/urandom for
          * random numbers in accordance with best practices
          * 
          * Why we use /dev/urandom and not /dev/random
          * @ref http://sockpuppet.org/blog/2014/02/25/safely-generate-random-numbers
-         * 
-         * /dev/arandom is not a typo 
-         * @ref http://nixdoc.net/man-pages/openbsd/man4/arandom.4.html
          * 
          * @param int $bytes
          * 
@@ -83,21 +74,9 @@ if (!function_exists('random_bytes')) {
                  * want to read from the operating system's CSPRNG device.
                  * 
                  * On some OS's 'rdev' might be -1. In these cases, we want to
-                 * verify that the filetype() of arandom/urandom is 'char'
-                 */
-                if (is_readable('/dev/arandom') && !is_link('/dev/arandom')) {
-                    /**
-                     * Okay, we can read data from /dev/arandom; is it a real device?
-                     */
-                    $stat = stat('/dev/arandom');
-                    $rdev = $stat['rdev'];
-                    if ($rdev !== 0 && filetype('/dev/arandom') === 'char') {
-                        $fp = fopen('/dev/arandom', 'rb');
-                    }
-                }
-                /**
-                 * If /dev/arandom doesn't exist (and/or is not a char device)
-                 * we use /dev/urandom. We never fall back to /dev/random.
+                 * verify that the filetype() of urandom is 'char'
+                 *
+                 * We use /dev/urandom. We never fall back to /dev/random.
                  */
                 if ($fp === null && is_readable('/dev/urandom')) {
                     /**


### PR DESCRIPTION
/dev/arandom is a deprecated OpenBSD-only char device, which became
an alias for /dev/urandom in OpenBSD 5.5, for the sole purpose of
supporting old software that might still be referencing it.

None of the supported versions of OpenBSD have /dev/arandom and
/dev/urandom use different code, and /dev/arandom was replaced with
/dev/urandom in all OpenBSD userland code quite a long time ago.