### PR TITLE
Remove version field from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name":         "paragonie/random_compat",
     "description":  "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-    "version":      "0.9.5",
     "keywords": [
             "csprng",
             "random",


### PR DESCRIPTION
Recommended so that version can be automatically (properly) determined from tags and branches.

See https://getcomposer.org/doc/04-schema.md#version