### PR TITLE
Use PHP_VERSION_ID to check the PHP version

### DIFF
--- a/lib/random.php
+++ b/lib/random.php
@@ -50,7 +50,7 @@ if (!function_exists('random_bytes')) {
      if (!ini_get('open_basedir') && is_readable('/dev/urandom')) {
         // See random_bytes_dev_urandom.php
         require_once "random_bytes_dev_urandom.php";
-    } elseif (function_exists('mcrypt_create_iv') && version_compare(PHP_VERSION, '5.3.7') >= 0) {
+    } elseif (PHP_VERSION_ID >= 50307 && function_exists('mcrypt_create_iv')) {
         // See random_bytes_mcrypt.php
         require_once "random_bytes_mcrypt.php";
     } elseif (extension_loaded('com_dotnet')) {


### PR DESCRIPTION
Using the ``PHP_VERSION_ID`` saves a method call, and allows the condition to be optimized at compile time by OPCache (it can inline the constant as it knows it, and it can then inline the condition).

note that this means that the library requires at least PHP 5.2.7 (this is when the constant was introduced). For me, it is not an issue at all (someone using an older version than 5.2.7 has much bigger issues than the need for a safe CSPRNG anyway).