### PR TITLE
Require versions of PHP less than 7 only

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
     },
     "autoload": {
         "files": ["lib/random.php"]
+    },
+    "require": {
+        "php": "<7"
     }
 }


### PR DESCRIPTION
Ensures that when installing with Composer, users using PHP7 will not be able to install this package. I see there is prevention in place (`function_exists` calls), but if the library is not even required, then the user should be told up front that this package is incompatible with their system.