### PR TITLE
Revert "Require versions of PHP less than 7 only"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,5 @@
     },
     "autoload": {
         "files": ["lib/random.php"]
-    },
-    "require": {
-        "php": "<7"
     }
 }


### PR DESCRIPTION
Reverts paragonie/random_compat#28

Actually, while this might save a function_exists lookup, it prevents the polyfill from being used in PHP7 projects. The idea behind random_compat is to allow a seamless upgrade and forward compatibility. Making it uninstallable as a dependency on PHP7 is not orthogonal to this goal.