### PR TITLE
version constraint due to PHP_VERSION_ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+composer.lock
 /vendor/

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "email":    "info@paragonie.com",
         "source":   "https://github.com/paragonie/random_compat"
     },
+    "require": {
+        "php": ">=5.2.7"
+    },
     "autoload": {
         "files": ["lib/random.php"]
     }


### PR DESCRIPTION
The use of `PHP_VERSION_ID` forces a minimum php version of 5.2.7. [See docs](http://php.net/manual/en/reserved.constants.php#constant.php-version-id)
No big deal but still good to have it written down