### PR TITLE
Check mbstring.func_overload value rather than for existing functions.

### DIFF
--- a/lib/byte_safe_strings.php
+++ b/lib/byte_safe_strings.php
@@ -27,7 +27,7 @@
  */
  
 if (!function_exists('RandomCompat_strlen')) {
-    if (function_exists('mb_strlen')) {
+    if (ini_get('mbstring.func_overload') & 2) {
         /**
          * strlen() implementation that isn't brittle to mbstring.func_overload
          * 
@@ -74,7 +74,7 @@ if (!function_exists('RandomCompat_strlen')) {
 }
 
 if (!function_exists('RandomCompat_substr')) {
-    if (function_exists('mb_substr')) {
+    if (ini_get('mbstring.func_overload') & 2) {
         /**
          * substr() implementation that isn't brittle to mbstring.func_overload
          * 


### PR DESCRIPTION
Check for the actual ini value rather than the mere existence of mb_* functions.