### PR TITLE
correct @throws in docblocks

### DIFF
--- a/lib/byte_safe_strings.php
+++ b/lib/byte_safe_strings.php
@@ -1,22 +1,22 @@
 <?php
 /**
- * Random_* Compatibility Library 
+ * Random_* Compatibility Library
  * for using the new PHP 7 random_* API in PHP 5 projects
- * 
+ *
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Paragon Initiative Enterprises
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,19 +25,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
- 
+
 if (!function_exists('RandomCompat_strlen')) {
     if (function_exists('mb_strlen')) {
         /**
          * strlen() implementation that isn't brittle to mbstring.func_overload
-         * 
+         *
          * This version uses mb_strlen() in '8bit' mode to treat strings as raw
          * binary rather than UTF-8, ISO-8859-1, etc
-         * 
+         *
          * @param string $binary_string
-         * 
-         * @throws InvalidArgumentException
-         * 
+         *
+         * @throws TypeError
+         *
          * @return int
          */
         function RandomCompat_strlen($binary_string)
@@ -52,13 +52,13 @@ if (!function_exists('RandomCompat_strlen')) {
     } else {
         /**
          * strlen() implementation that isn't brittle to mbstring.func_overload
-         * 
+         *
          * This version just used the default strlen()
-         * 
+         *
          * @param string $binary_string
-         * 
-         * @throws InvalidArgumentException
-         * 
+         *
+         * @throws TypeError
+         *
          * @return int
          */
         function RandomCompat_strlen($binary_string)
@@ -77,16 +77,16 @@ if (!function_exists('RandomCompat_substr')) {
     if (function_exists('mb_substr')) {
         /**
          * substr() implementation that isn't brittle to mbstring.func_overload
-         * 
+         *
          * This version uses mb_substr() in '8bit' mode to treat strings as raw
          * binary rather than UTF-8, ISO-8859-1, etc
-         * 
+         *
          * @param string $binary_string
          * @param int $start
          * @param int $length (optional)
-         * 
-         * @throws InvalidArgumentException
-         * 
+         *
+         * @throws TypeError
+         *
          * @return string
          */
         function RandomCompat_substr($binary_string, $start, $length = null)
@@ -117,15 +117,15 @@ if (!function_exists('RandomCompat_substr')) {
     } else {
         /**
          * substr() implementation that isn't brittle to mbstring.func_overload
-         * 
+         *
          * This version just uses the default substr()
-         * 
+         *
          * @param string $binary_string
          * @param int $start
          * @param int $length (optional)
-         * 
-         * @throws InvalidArgumentException
-         * 
+         *
+         * @throws TypeError
+         *
          * @return string
          */
         function RandomCompat_substr($binary_string, $start, $length = null)


### PR DESCRIPTION
Correct trows docblocks from `InvalidArgumentException` to `TypeError`

Sorry for the trailing spaces removal, editor configuration