### PR TITLE
PHP7 input type compatibility

### DIFF
--- a/lib/random_int.php
+++ b/lib/random_int.php
@@ -53,8 +53,8 @@ if (!function_exists('random_int')) {
             );
         }
 
-		$min = (int)$min;
-		$max = (int)$max;
+        $min = (int)$min;
+        $max = (int)$max;
 
         if ($min > $max) {
             throw new Error(

--- a/lib/random_int.php
+++ b/lib/random_int.php
@@ -37,7 +37,8 @@ if (!function_exists('random_int')) {
      * 
      * @return int
      */
-    function random_int($min, $max) {
+    function random_int($min, $max)
+    {
         /**
          * Type and input logic checks
          */

--- a/lib/random_int.php
+++ b/lib/random_int.php
@@ -37,21 +37,24 @@ if (!function_exists('random_int')) {
      * 
      * @return int
      */
-    function random_int($min, $max)
-    {
+    function random_int($min, $max) {
         /**
          * Type and input logic checks
          */
-        if (!is_int($min)) {
+        if (!is_numeric($min)) {
             throw new TypeError(
                 'random_int(): $min must be an integer'
             );
         }
-        if (!is_int($max)) {
+        if (!is_numeric($max)) {
             throw new TypeError(
                 'random_int(): $max must be an integer'
             );
         }
+
+		$min = (int)$min;
+		$max = (int)$max;
+
         if ($min > $max) {
             throw new Error(
                 'Minimum value must be less than or equal to the maximum value'

--- a/tests/unit/RandomIntTest.php
+++ b/tests/unit/RandomIntTest.php
@@ -13,14 +13,19 @@ class RandomIntTest extends PHPUnit_Framework_TestCase
             random_int(1001,2000),
             random_int(-100, -10),
             random_int(-1000, 1000),
-            random_int(~PHP_INT_MAX, PHP_INT_MAX)
+            random_int(~PHP_INT_MAX, PHP_INT_MAX),
+            random_int("0", "1"),
+            random_int(0.11111, 0.99999),
         );
-        
+
         $this->assertFalse($integers[0] === $integers[1]);
         $this->assertTrue($integers[0] >= 0 && $integers[0] <= 1000);
         $this->assertTrue($integers[1] >= 1001 && $integers[1] <= 2000);
         $this->assertTrue($integers[2] >= -100 && $integers[2] <= -10);
         $this->assertTrue($integers[3] >= -1000 && $integers[3] <= 1000);
         $this->assertTrue($integers[4] >= ~PHP_INT_MAX && $integers[4] <= PHP_INT_MAX);
+        $this->assertTrue($integers[5] >= 0 && $integers[5] <= 1);
+        $this->assertTrue($integers[6] === 0);
+        
     }
 }

--- a/tests/unit/RandomIntTest.php
+++ b/tests/unit/RandomIntTest.php
@@ -17,7 +17,7 @@ class RandomIntTest extends PHPUnit_Framework_TestCase
             random_int("0", "1"),
             random_int(0.11111, 0.99999),
         );
-
+        
         $this->assertFalse($integers[0] === $integers[1]);
         $this->assertTrue($integers[0] >= 0 && $integers[0] <= 1000);
         $this->assertTrue($integers[1] >= 1001 && $integers[1] <= 2000);
@@ -26,6 +26,5 @@ class RandomIntTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($integers[4] >= ~PHP_INT_MAX && $integers[4] <= PHP_INT_MAX);
         $this->assertTrue($integers[5] >= 0 && $integers[5] <= 1);
         $this->assertTrue($integers[6] === 0);
-        
     }
 }


### PR DESCRIPTION
It appears that although the PHP7 documentation says it requires Integers, it accepts numeric types instead. This includes floats and numeric strings.

random_compat however, only accepts pure integers, no floats or numeric strings. This PR is an attempt at adding that support.