### PR TITLE
Avoid a PHP Notice when PHP is running without the mbstring extension.

### DIFF
--- a/lib/byte_safe_strings.php
+++ b/lib/byte_safe_strings.php
@@ -27,7 +27,7 @@
  */
 
 if (!function_exists('RandomCompat_strlen')) {
-    if (ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING) {
+    if (defined('MB_OVERLOAD_STRING') && ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING) {
         /**
          * strlen() implementation that isn't brittle to mbstring.func_overload
          *
@@ -74,7 +74,7 @@ if (!function_exists('RandomCompat_strlen')) {
 }
 
 if (!function_exists('RandomCompat_substr')) {
-    if (ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING) {
+    if (defined('MB_OVERLOAD_STRING') && ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING) {
         /**
          * substr() implementation that isn't brittle to mbstring.func_overload
          *


### PR DESCRIPTION
Fixes #37 