### PR TITLE
Use extension_loaded() instead of checking that a function exists.

### DIFF
--- a/lib/random.php
+++ b/lib/random.php
@@ -55,13 +55,13 @@ if (PHP_VERSION_ID < 70000) {
         if (!ini_get('open_basedir') && is_readable('/dev/urandom')) {
             // See random_bytes_dev_urandom.php
             require_once "random_bytes_dev_urandom.php";
-        } elseif (PHP_VERSION_ID >= 50307 && function_exists('mcrypt_create_iv')) {
+        } elseif (PHP_VERSION_ID >= 50307 && extension_loaded('mcrypt')) {
             // See random_bytes_mcrypt.php
             require_once "random_bytes_mcrypt.php";
         } elseif (extension_loaded('com_dotnet')) {
             // See random_bytes_com_dotnet.php
             require_once "random_bytes_com_dotnet.php";
-        } elseif (function_exists('openssl_random_pseudo_bytes')) {
+        } elseif (extension_loaded('openssl')) {
             // See random_bytes_openssl.php
             require_once "random_bytes_openssl.php";
         } else {


### PR DESCRIPTION
My interest here is indirectly for https://github.com/cweagans/mcrypt-polyfill.

The mcrypt_* functions in my library will call phpseclib functions. I hope to remove the phpseclib Random class and replace it with random_compat, so ensuring there aren't circular function calls here is very important to me.