### PR TITLE
Don't define random_bytes() at all if there's no reasonable way to do it

### DIFF
--- a/lib/random.php
+++ b/lib/random.php
@@ -66,15 +66,9 @@ if (PHP_VERSION_ID < 70000) {
             require_once "random_bytes_openssl.php";
         } else {
             /**
-             * We don't have any more options, so let's throw an exception right now
-             * and hope the developer won't let it fail silently.
+             * We don't have any other options, so we'll leave the random_bytes()
+             * function undefined.
              */
-            function random_bytes()
-            {
-                throw new Exception(
-                    'There is no suitable CSPRNG installed on your system'
-                );
-            }
         }
     }
     if (!function_exists('random_int')) {


### PR DESCRIPTION
The use case here is that https://github.com/phpseclib/phpseclib/blob/master/phpseclib/Crypt/Random.php defines a pure PHP PRNG if no other acceptable sources of randomness are available, so in adopting this lib, phpseclib can just define it's own `random_bytes()` function with the pure PHP PRNG implementation.

My thinking is that the polyfill can only do so much, but defining a random_bytes() function that just throws an exception isn't very helpful.

Eventually, I think it'd be cool to move the pure PHP PRNG implementation from phpseclib over to this library in another include, but as it is right now, it's pretty strongly tied to the rest of phpseclib, so it's kind of unrealistic at this point.