### PR TITLE
Exceptions should implement throwable

### DIFF
--- a/lib/error_polyfill.php
+++ b/lib/error_polyfill.php
@@ -46,3 +46,13 @@ if (!class_exists('TypeError', false)) {
         
     }
 }
+
+if (!class_exists('RandomCompatException', false)) {
+	// Only provided so that thrown exceptions implement Throwable.
+	// Allows implementing code to catch Throwable which is compatible
+	// with PHP7.
+	class RandomCompatException extends Exception implements Throwable
+	{
+
+	}
+}

--- a/lib/error_polyfill.php
+++ b/lib/error_polyfill.php
@@ -29,14 +29,6 @@
 if (!interface_exists('Throwable', false)) {
     interface Throwable
     {
-        public function getMessage();
-        public function getCode();
-        public function getFile();
-        public function getLine();
-        public function getTrace();
-        public function getTraceAsString();
-        public function getPrevious();
-        public function __toString();
     }
 }
 

--- a/lib/random.php
+++ b/lib/random.php
@@ -71,7 +71,7 @@ if (PHP_VERSION_ID < 70000) {
              */
             function random_bytes()
             {
-                throw new Exception(
+                throw new RandomCompatException(
                     'There is no suitable CSPRNG installed on your system'
                 );
             }

--- a/lib/random_bytes_com_dotnet.php
+++ b/lib/random_bytes_com_dotnet.php
@@ -69,7 +69,7 @@ function random_bytes($bytes)
     /**
      * If we reach here, PHP has failed us.
      */
-    throw new Exception(
+    throw new RandomCompatException(
         'PHP failed to generate random data.'
     );
 }

--- a/lib/random_bytes_dev_urandom.php
+++ b/lib/random_bytes_dev_urandom.php
@@ -129,7 +129,7 @@ function random_bytes($bytes)
     /**
      * If we reach here, PHP has failed us.
      */
-    throw new Exception(
+    throw new RandomCompatException(
         'PHP failed to generate random data.'
     );
 }

--- a/lib/random_bytes_mcrypt.php
+++ b/lib/random_bytes_mcrypt.php
@@ -64,7 +64,7 @@ function random_bytes($bytes)
     /**
      * If we reach here, PHP has failed us.
      */
-    throw new Exception(
+    throw new RandomCompatException(
         'PHP failed to generate random data.'
     );
 }

--- a/lib/random_bytes_openssl.php
+++ b/lib/random_bytes_openssl.php
@@ -68,7 +68,7 @@ function random_bytes($bytes)
     /**
      * If we reach here, PHP has failed us.
      */
-    throw new Exception(
+    throw new RandomCompatException(
         'PHP failed to generate random data.'
     );
 }

--- a/lib/random_int.php
+++ b/lib/random_int.php
@@ -124,7 +124,7 @@ function random_int($min, $max)
          * to a failure probability of 2^-128 for a working RNG
          */
         if ($attempts > 128) {
-            throw new Exception(
+            throw new RandomCompatException(
                 'random_int: RNG is broken - too many rejections'
             );
         }
@@ -134,7 +134,7 @@ function random_int($min, $max)
          */
         $randomByteString = random_bytes($bytes);
         if ($randomByteString === false) {
-            throw new Exception(
+            throw new RanndomCompatException(
                 'Random number generator failure'
             );
         }


### PR DESCRIPTION
Currently this polyfill throws `Exception` objects like PHP7 but the thrown object does not implement the `Throwable` interface, so it's not possible to use a `catch (\Throwable $e)` construct to catch all errors. To ensure compatibility with PHP7 and PHP5 implementers would need to catch both `Exception` and `Throwable`.

To work around this I have created a `RandomCompatExeception` allowing the same calling code to be used with the polyfill and PHP7. For consumers `RandomCompatExeception` should be considered an implementation detail, hence I have not changed the phpdoc comments.