### PR TITLE
Relax open_basedir restriction

### DIFF
--- a/lib/random.php
+++ b/lib/random.php
@@ -56,7 +56,7 @@ if (PHP_VERSION_ID < 70000) {
         if (extension_loaded('libsodium')) {
             // See random_bytes_libsodium.php
             require_once "random_bytes_libsodium.php";
-        } elseif (!ini_get('open_basedir') && is_readable('/dev/urandom')) {
+        } elseif (@is_readable('/dev/urandom')) {
             // See random_bytes_dev_urandom.php
             require_once "random_bytes_dev_urandom.php";
         } elseif (PHP_VERSION_ID >= 50307 && extension_loaded('mcrypt')) {


### PR DESCRIPTION
We really only care whether or not `/dev/urandom` is readable. `open_basedir`, of course, makes that not readable unless `/dev` is whitelisted in php.ini.

Did some testing locally and this works as expected:

1) `open_basedir` disabled: `/dev/urandom` readable
2) `open_basedir` enabled (restricted to `.`): `/dev/urandom` unreadable
3) `open_basedir` enabled (restricted to `.:/dev`): `/dev/urandom` readable

Warnings on scenario 2 are appropriately silenced by `@`.

Fixes #46.