### PR TITLE
Fixes string to integer conversions.

### DIFF
--- a/lib/cast_to_int.php
+++ b/lib/cast_to_int.php
@@ -45,6 +45,12 @@ if (!function_exists('RandomCompat_intval')) {
     function RandomCompat_intval($number, $fail_open = false)
     {
         if (
+            is_string($number) &&
+            preg_match('#^\-?[0-9]+\.?[0-9]*$#', $number)
+        ) {
+            $number += 0;
+        }
+        if (
             is_float($number) &&
             $number > ~PHP_INT_MAX &&
             $number < PHP_INT_MAX
@@ -54,17 +60,6 @@ if (!function_exists('RandomCompat_intval')) {
                     ? ceil($number)
                     : floor($number)
             );
-        } elseif (
-            is_string($number) &&
-            preg_match('#^\-?[0-9]+\.[0-9]+$#', $number)
-        ) {
-            $number = (int) (
-                $number < 0
-                    ? ceil($number)
-                    : floor($number)
-            );
-        } elseif (is_string($number) && preg_match('#^\-?[0-9]+$#', $number)) {
-            $number = (int) $number;
         }
         if (is_int($number) || $fail_open) {
             return $number;


### PR DESCRIPTION
These were previously working differently than in PHP 7.0.0rc5
var_dump(random_int("9223372036854775808","9223372036854775807"));
var_dump(random_int("1.","1."));