### PR TITLE
Add support for a user-defined fallback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,19 @@ try {
 }
 ```
 
+## Fallback function
+
+> NOTE: Using a fallback function to utilize a PRNG written in PHP is strongly
+  discouraged. Applications using `random_bytes()` assume that the result
+  is going to be cryptographically strong, and a pure PHP PRNG is not that.
+
+If no other sources of randomness can be found, this library will attempt to
+call the function `random_bytes_fallback()` if the function is defined.
+
+If you want to use random.org (as an example) for a source of random numbers,
+this would be a good way to acheive that. Ditto for using a hardware random
+number generator.
+
 ## Contributors
 
 This project would not be anywhere near as excellent as it is today if it 

--- a/lib/random.php
+++ b/lib/random.php
@@ -81,12 +81,19 @@ if (PHP_VERSION_ID < 70000) {
             // See random_bytes_openssl.php
             require_once "$__DIR__/random_bytes_openssl.php";
         } else {
-            /**
-             * We don't have any more options, so let's throw an exception right now
-             * and hope the developer won't let it fail silently.
-             */
-            function random_bytes()
+            function random_bytes($bytes)
             {
+                // Pass through to a user-defined fallback function if it's defined.
+                // Not recommended, but potentially useful for unforeseen
+                // applications of this library. For instance, the fallback function
+                // could pull random data from random.org or a hardware randomn
+                // number generator.
+                if (function_exists('random_bytes_fallback')) {
+                    return random_bytes_fallback($bytes);
+                }
+
+                // We don't have any more options, so let's throw an exception
+                // and hope the developer won't let it fail silently.
                 throw new Exception(
                     'There is no suitable CSPRNG installed on your system'
                 );


### PR DESCRIPTION
Fixes https://github.com/paragonie/random_compat/issues/61 without actually adding a PHP PRNG.

Also allows this library to use random number generator *hardware* modules or random.org (or any number of other sources) as a source for random data.

Hopefully the warning in `README.md` is strong enough to make this an acceptable proposal.