### PR TITLE
Remove Throwable polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,11 @@ The differences:
 
 * Catching `Error` works, so long as it is caught before `Exception`.
 * Catching `Exception` has different behavior, without previously catching `Error`.
-* Catching `Throwable` does *not* work the same between PHP5 and PHP7.
 * There is *no* portable way to catch all errors/exceptions.
 
 #### Our recommendation
 
-**Always** catch `Error` before `Exception`, **do not** catch `Throwable`.
+**Always** catch `Error` before `Exception`.
 
 #### Example
 

--- a/lib/error_polyfill.php
+++ b/lib/error_polyfill.php
@@ -26,15 +26,9 @@
  * SOFTWARE.
  */
 
-if (!interface_exists('Throwable', false)) {
-    interface Throwable
-    {
-    }
-}
-
 if (!class_exists('Error', false)) {
     // We can't really avoid making this extend Exception in PHP 5.
-    class Error extends Exception implements Throwable
+    class Error extends Exception
     {
         
     }


### PR DESCRIPTION
Polyfilling Throwable is not required for random_* functions to work correctly. But by creating a `Throwable` interface that is not implemented by `Exception`, `$exception instanceof Throwable` returns `false` in PHP5 and `true` on PHP7. This is a serious issue.
Since there is no way to correctly shim Throwable on PHP5, I'd like this to be removed.