### PR TITLE
Since calling mcrypt will involve MCRYPT_DEV_URANDOM which might not …

### DIFF
--- a/lib/random.php
+++ b/lib/random.php
@@ -129,6 +129,8 @@ if (PHP_VERSION_ID < 70000) {
             PHP_VERSION_ID >= 50307
             &&
             extension_loaded('mcrypt')
+            &&
+            @is_readable(MCRYPT_DEV_URANDOM)
         ) {
             // Prevent this code from hanging indefinitely on non-Windows;
             // see https://bugs.php.net/bug.php?id=69833


### PR DESCRIPTION
…be present, ensure it is present and readable. Or an exception will be thrown if mcrypt is installed and MCRYPT_DEV_URANDOM is not usable, thus preventing the use of the next means of getting random data.