### PR TITLE
Update phpunit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,8 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"


### PR DESCRIPTION
We can prevent risky tests and warnings and make the tests fail.