### PR TITLE
update to version 5.3.3 for mcrypt use

### DIFF
--- a/lib/random.php
+++ b/lib/random.php
@@ -127,7 +127,7 @@ if (PHP_VERSION_ID < 70000) {
         if (
             !function_exists('random_bytes')
             &&
-            PHP_VERSION_ID >= 50307
+            PHP_VERSION_ID >= 50303
             &&
             extension_loaded('mcrypt')
             &&


### PR DESCRIPTION
My web host is still in PHP 5.3.3, but it have the mcrypt extension installed. So I recommend to downgrad the minimum version of PHP required for using mcrypt.
