### PR TITLE
explicitly cast values to int

### DIFF
--- a/lib/random.php
+++ b/lib/random.php
@@ -31,12 +31,12 @@
 
 if (!defined('PHP_VERSION_ID')) {
     // This constant was introduced in PHP 5.2.7
-    $RandomCompatversion = explode('.', PHP_VERSION);
+    $RandomCompatversion = array_map('intval', explode('.', PHP_VERSION));
     define(
         'PHP_VERSION_ID',
-        (int) $RandomCompatversion[0] * 10000
-        + (int) $RandomCompatversion[1] * 100
-        + (int) $RandomCompatversion[2]
+        $RandomCompatversion[0] * 10000
+        + $RandomCompatversion[1] * 100
+        + $RandomCompatversion[2]
     );
     $RandomCompatversion = null;
 }

--- a/lib/random.php
+++ b/lib/random.php
@@ -34,9 +34,9 @@ if (!defined('PHP_VERSION_ID')) {
     $RandomCompatversion = explode('.', PHP_VERSION);
     define(
         'PHP_VERSION_ID',
-        $RandomCompatversion[0] * 10000
-        + $RandomCompatversion[1] * 100
-        + $RandomCompatversion[2]
+        (int) $RandomCompatversion[0] * 10000
+        + (int) $RandomCompatversion[1] * 100
+        + (int) $RandomCompatversion[2]
     );
     $RandomCompatversion = null;
 }


### PR DESCRIPTION
This is needed because, per [this PHP RFC](https://wiki.php.net/rfc/invalid_strings_in_arithmetic), PHP 7.1 will throw errors when not explicitly casted numeric values are used in arithmetic.