### PR TITLE
fix 1.x version number

### DIFF
--- a/lib/random.php
+++ b/lib/random.php
@@ -3,7 +3,7 @@
  * Random_* Compatibility Library
  * for using the new PHP 7 random_* API in PHP 5 projects
  *
- * @version 2.0.4
+ * @version 1.4.2
  * @released 2016-11-07
  *
  * The MIT License (MIT)


### PR DESCRIPTION
We might update the `v1.4.2` tag as well? Or create `v1.4.3`?