### PR TITLE
cleanup after openssl removal

### DIFF
--- a/phpunit.sh
+++ b/phpunit.sh
@@ -47,8 +47,6 @@ if [[ "$testeach" == "1" ]]; then
     php vendor/bin/phpunit --bootstrap tests/specific/libsodium.php tests/unit
     echo "    mcrypt:"
     php vendor/bin/phpunit --bootstrap tests/specific/mcrypt.php tests/unit
-    echo "    openssl:"
-    php vendor/bin/phpunit --bootstrap tests/specific/openssl.php tests/unit
 fi
 
 # Should we perform full statistical analyses?


### PR DESCRIPTION
`tests/specific/openssl.php` no longer exists after 1c435ec

ps: @paragonie-scott should write more meaningful commit messages, was pretty hard to find that commit. https://chris.beams.io/posts/git-commit/