### PR TITLE
Removed random int test in autoloader

### DIFF
--- a/psalm-autoload.php
+++ b/psalm-autoload.php
@@ -6,4 +6,3 @@ require_once 'lib/error_polyfill.php';
 require_once 'other/ide_stubs/libsodium.php';
 require_once 'lib/random.php';
 
-$int = random_int(0, 65536);


### PR DESCRIPTION
The random_int() function call came up at an external security audit asking us if the entropy would be high enough to base any crypto on it etc. - I then looked at it and it seems just to be a check wether the polyfill is working or not, right?
Can't we maybe get rid of that alltogether or otherwise add a comment why this is there?