### PR TITLE
Replace is_callable with the faster function_exists

### DIFF
--- a/lib/byte_safe_strings.php
+++ b/lib/byte_safe_strings.php
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-if (!is_callable('RandomCompat_strlen')) {
+if (!function_exists('RandomCompat_strlen')) {
     if (
         defined('MB_OVERLOAD_STRING') &&
         ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING
@@ -78,7 +78,7 @@ if (!is_callable('RandomCompat_strlen')) {
     }
 }
 
-if (!is_callable('RandomCompat_substr')) {
+if (!function_exists('RandomCompat_substr')) {
 
     if (
         defined('MB_OVERLOAD_STRING')

--- a/lib/cast_to_int.php
+++ b/lib/cast_to_int.php
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-if (!is_callable('RandomCompat_intval')) {
+if (!function_exists('RandomCompat_intval')) {
     
     /**
      * Cast to an integer if we can, safely.

--- a/lib/random.php
+++ b/lib/random.php
@@ -58,7 +58,7 @@ require_once $RandomCompatDIR . '/byte_safe_strings.php';
 require_once $RandomCompatDIR . '/cast_to_int.php';
 require_once $RandomCompatDIR . '/error_polyfill.php';
 
-if (!is_callable('random_bytes')) {
+if (!function_exists('random_bytes')) {
     /**
      * PHP 5.2.0 - 5.6.x way to implement random_bytes()
      *
@@ -104,7 +104,7 @@ if (!is_callable('random_bytes')) {
         }
 
         if (
-            !is_callable('random_bytes')
+            !function_exists('random_bytes')
             &&
             $RandomCompatUrandom
             &&
@@ -144,7 +144,7 @@ if (!is_callable('random_bytes')) {
      *     we get insufficient entropy errors.
      */
     if (
-        !is_callable('random_bytes')
+        !function_exists('random_bytes')
         &&
         // Windows on PHP < 5.3.7 is broken, but non-Windows is not known to be.
         (DIRECTORY_SEPARATOR === '/' || PHP_VERSION_ID >= 50307)
@@ -168,7 +168,7 @@ if (!is_callable('random_bytes')) {
      * isn't loaded.
      */
     if (
-        !is_callable('random_bytes')
+        !function_exists('random_bytes')
         &&
         extension_loaded('com_dotnet')
         &&
@@ -197,7 +197,7 @@ if (!is_callable('random_bytes')) {
     /**
      * throw new Exception
      */
-    if (!is_callable('random_bytes')) {
+    if (!function_exists('random_bytes')) {
         /**
          * We don't have any more options, so let's throw an exception right now
          * and hope the developer won't let it fail silently.
@@ -216,7 +216,7 @@ if (!is_callable('random_bytes')) {
     }
 }
 
-if (!is_callable('random_int')) {
+if (!function_exists('random_int')) {
     require_once $RandomCompatDIR . '/random_int.php';
 }
 

--- a/lib/random_bytes_com_dotnet.php
+++ b/lib/random_bytes_com_dotnet.php
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-if (!is_callable('random_bytes')) {
+if (!function_exists('random_bytes')) {
     /**
      * Windows with PHP < 5.3.0 will not have the function
      * openssl_random_pseudo_bytes() available, so let's use

--- a/lib/random_bytes_dev_urandom.php
+++ b/lib/random_bytes_dev_urandom.php
@@ -30,7 +30,7 @@ if (!defined('RANDOM_COMPAT_READ_BUFFER')) {
     define('RANDOM_COMPAT_READ_BUFFER', 8);
 }
 
-if (!is_callable('random_bytes')) {
+if (!function_exists('random_bytes')) {
     /**
      * Unless open_basedir is enabled, use /dev/urandom for
      * random numbers in accordance with best practices
@@ -73,10 +73,10 @@ if (!is_callable('random_bytes')) {
                  *
                  * stream_set_read_buffer returns 0 on success
                  */
-                if (is_callable('stream_set_read_buffer')) {
+                if (function_exists('stream_set_read_buffer')) {
                     stream_set_read_buffer($fp, RANDOM_COMPAT_READ_BUFFER);
                 }
-                if (is_callable('stream_set_chunk_size')) {
+                if (function_exists('stream_set_chunk_size')) {
                     stream_set_chunk_size($fp, RANDOM_COMPAT_READ_BUFFER);
                 }
             }

--- a/lib/random_bytes_libsodium.php
+++ b/lib/random_bytes_libsodium.php
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-if (!is_callable('random_bytes')) {
+if (!function_exists('random_bytes')) {
     /**
      * If the libsodium PHP extension is loaded, we'll use it above any other
      * solution.

--- a/lib/random_bytes_libsodium_legacy.php
+++ b/lib/random_bytes_libsodium_legacy.php
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-if (!is_callable('random_bytes')) {
+if (!function_exists('random_bytes')) {
     /**
      * If the libsodium PHP extension is loaded, we'll use it above any other
      * solution.

--- a/lib/random_bytes_mcrypt.php
+++ b/lib/random_bytes_mcrypt.php
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-if (!is_callable('random_bytes')) {
+if (!function_exists('random_bytes')) {
     /**
      * Powered by ext/mcrypt (and thankfully NOT libmcrypt)
      *

--- a/lib/random_int.php
+++ b/lib/random_int.php
@@ -1,6 +1,6 @@
 <?php
 
-if (!is_callable('random_int')) {
+if (!function_exists('random_int')) {
     /**
      * Random_* Compatibility Library
      * for using the new PHP 7 random_* API in PHP 5 projects


### PR DESCRIPTION
According to my own testing, `function_exists` performs better than `is_callable` for normal functions. Additionally, I see no downside to `function_exists` compared to `is_callable`.

I did not change the `is_callable` call to libsodium's `randombytes_buf` function, since that call is to a class method, which is not handled by `function_exists`.

My apologies if I missed something, I checked the rationale and existing issues, but it didn't seem like this was yet considered.