### PR TITLE
Fix require path for windows

### DIFF
--- a/lib/random.php
+++ b/lib/random.php
@@ -54,9 +54,9 @@ if (!defined('RANDOM_COMPAT_READ_BUFFER')) {
 
 $RandomCompatDIR = dirname(__FILE__);
 
-require_once $RandomCompatDIR . '/byte_safe_strings.php';
-require_once $RandomCompatDIR . '/cast_to_int.php';
-require_once $RandomCompatDIR . '/error_polyfill.php';
+require_once $RandomCompatDIR . DIRECTORY_SEPARATOR . 'byte_safe_strings.php';
+require_once $RandomCompatDIR . DIRECTORY_SEPARATOR . 'cast_to_int.php';
+require_once $RandomCompatDIR . DIRECTORY_SEPARATOR . 'error_polyfill.php';
 
 if (!is_callable('random_bytes')) {
     /**
@@ -76,9 +76,9 @@ if (!is_callable('random_bytes')) {
     if (extension_loaded('libsodium')) {
         // See random_bytes_libsodium.php
         if (PHP_VERSION_ID >= 50300 && is_callable('\\Sodium\\randombytes_buf')) {
-            require_once $RandomCompatDIR . '/random_bytes_libsodium.php';
+            require_once $RandomCompatDIR . DIRECTORY_SEPARATOR . 'random_bytes_libsodium.php';
         } elseif (method_exists('Sodium', 'randombytes_buf')) {
-            require_once $RandomCompatDIR . '/random_bytes_libsodium_legacy.php';
+            require_once $RandomCompatDIR . DIRECTORY_SEPARATOR . 'random_bytes_libsodium_legacy.php';
         }
     }
 
@@ -117,7 +117,7 @@ if (!is_callable('random_bytes')) {
             // place, that is not helpful to us here.
 
             // See random_bytes_dev_urandom.php
-            require_once $RandomCompatDIR . '/random_bytes_dev_urandom.php';
+            require_once $RandomCompatDIR . DIRECTORY_SEPARATOR . 'random_bytes_dev_urandom.php';
         }
         // Unset variables after use
         $RandomCompat_basedir = null;
@@ -159,7 +159,7 @@ if (!is_callable('random_bytes')) {
         extension_loaded('mcrypt')
     ) {
         // See random_bytes_mcrypt.php
-        require_once $RandomCompatDIR . '/random_bytes_mcrypt.php';
+        require_once $RandomCompatDIR . DIRECTORY_SEPARATOR . 'random_bytes_mcrypt.php';
     }
     $RandomCompatUrandom = null;
 
@@ -184,7 +184,7 @@ if (!is_callable('random_bytes')) {
                 $RandomCompatCOMtest = new COM('CAPICOM.Utilities.1');
                 if (method_exists($RandomCompatCOMtest, 'GetRandom')) {
                     // See random_bytes_com_dotnet.php
-                    require_once $RandomCompatDIR . '/random_bytes_com_dotnet.php';
+                    require_once $RandomCompatDIR . DIRECTORY_SEPARATOR . 'random_bytes_com_dotnet.php';
                 }
             } catch (com_exception $e) {
                 // Don't try to use it.
@@ -220,7 +220,7 @@ if (!is_callable('random_bytes')) {
 }
 
 if (!is_callable('random_int')) {
-    require_once $RandomCompatDIR . '/random_int.php';
+    require_once $RandomCompatDIR . DIRECTORY_SEPARATOR . 'random_int.php';
 }
 
 $RandomCompatDIR = null;


### PR DESCRIPTION
In windows the generated path has the last separator wrong, using default PHP constant DIRECTORY_SEPARATOR allows your code to work correctly in both windows and *nix