### PR TITLE
Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     - php: "7.3"
       env: USE_PSALM=1
            CHECK_MBSTRING=0
-    - php: "7.4snapshot"
+    - php: "7.4"
       env: USE_PSALM=1
            CHECK_MBSTRING=0
     - php: "nightly"
@@ -46,12 +46,14 @@ matrix:
            CHECK_MBSTRING=0
   allow_failures:
     - php: "hhvm"
+    - php: "nightly"
     - php: "master"
+    - php: "7.4"
 
 install:
     - composer self-update
-    - composer install
     - if [[ $USE_PSALM -eq 1 ]]; then composer require --dev "vimeo/psalm:^0|^1|^2"; fi
+    - composer update
 
 script:
     - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "php": ">=5.2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.*|5.*"
+    "phpunit/phpunit": "^4.8.36|5.*|6.*|7.*"
   },
   "suggest": {
     "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."

--- a/lib/random.php
+++ b/lib/random.php
@@ -45,6 +45,7 @@ if (!defined('PHP_VERSION_ID')) {
  * PHP 7.0.0 and newer have these functions natively.
  */
 if (PHP_VERSION_ID >= 70000) {
+    class_alias('PHPUnit\\Framework\\TestCase', 'PHPUnit_Framework_TestCase');
     return;
 }
 

--- a/tests/full/DieHardTest.php
+++ b/tests/full/DieHardTest.php
@@ -2,7 +2,7 @@
 class DieHardTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * Birthday spacings: Choose random points on a large interval. 
+     * Birthday spacings: Choose random points on a large interval.
      * The spacings between the points should be asymptotically exponentially
      * distributed.
      */
@@ -15,10 +15,10 @@ class DieHardTest extends PHPUnit_Framework_TestCase
         $rand_min = 200000;
         $rand_max = 600000;
         $rand_step = 100000;
-        
+
         $minT = (1.00 - $tolerance);
         $maxT = (1.00 + $tolerance);
-        
+
         for ($nums_to_generate = $rand_min; $nums_to_generate < $rand_max; $nums_to_generate += $rand_step) {
             $buckets = array_fill(0, $num_buckets, 0);
 
@@ -32,14 +32,14 @@ class DieHardTest extends PHPUnit_Framework_TestCase
                 $buckets[$bucket]++;
             }
             for ($i = 0; $i < $num_buckets; ++$i) {
-                
+
                 // Debugging code:
-                
+
                 if ($buckets[$i] <= $min ) {
                     var_dump([
                         'bucket' => $i,
-                        'value' => $buckets[$i], 
-                        'min' => $min, 
+                        'value' => $buckets[$i],
+                        'min' => $min,
                         'nums' => $nums_to_generate,
                         'reason' => 'below min'
                     ]);
@@ -53,7 +53,7 @@ class DieHardTest extends PHPUnit_Framework_TestCase
                         'reason' => 'above max'
                     ]);
                 }
-                
+
                 $this->assertTrue($buckets[$i] < $max && $buckets[$i] > $min);
             }
         }

--- a/tests/full/StatTest.php
+++ b/tests/full/StatTest.php
@@ -1,10 +1,9 @@
 <?php
-
 class StatTest extends PHPUnit_Framework_TestCase
 {
     /**
      * All possible values should be > 30% but less than 170%
-     * 
+     *
      * This also catches 0 and 1000
      */
     public function testDistribution()
@@ -18,7 +17,7 @@ class StatTest extends PHPUnit_Framework_TestCase
             $this->assertFalse($integers[$i] > 170);
         }
     }
-    
+
     /**
      * This should be between 55% and 75%, always
      */
@@ -37,7 +36,7 @@ class StatTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($coverage >= 1150);
         $this->assertTrue($coverage <= 1350);
     }
-    
+
     public function testCompressionRatios()
     {
         $some_bytes = random_bytes(65536);

--- a/tests/unit/RandomBytesTest.php
+++ b/tests/unit/RandomBytesTest.php
@@ -5,7 +5,7 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
     {
         $this->assertTrue(function_exists('random_bytes'));
     }
-    
+
     public function testInvalidParams()
     {
         try {
@@ -18,7 +18,7 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
         } catch (Exception $ex) {
             $this->assertTrue(true);
         }
-        
+
         try {
             $bytes = random_bytes(array(12));
             $this->fail("random_bytes() should accept only an integer");
@@ -29,11 +29,11 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
         } catch (Exception $ex) {
             $this->assertTrue(true);
         }
-        
+
         // This should succeed:
         $bytes = random_bytes('123456');
     }
-    
+
     public function testOutput()
     {
         $bytes = array(
@@ -42,19 +42,19 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
             random_bytes(64),
             random_bytes(1.5)
         );
-        
+
         $this->assertTrue(
             strlen(bin2hex($bytes[0])) === 24
         );
         $this->assertTrue(
             strlen(bin2hex($bytes[3])) === 2
         );
-        
+
         // This should never generate identical byte strings
         $this->assertFalse(
             $bytes[1] === $bytes[2]
         );
-        
+
         try {
             $x = random_bytes(~PHP_INT_MAX - 1000000000);
             $this->fail("Integer overflow (~PHP_INT_MAX - 1000000000).");
@@ -65,7 +65,7 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
         } catch (Exception $ex) {
             $this->assertTrue(true);
         }
-        
+
         try {
             $x = random_bytes(PHP_INT_MAX + 1000000000);
             $this->fail("Requesting too many bytes should fail.");

--- a/tests/unit/RandomIntTest.php
+++ b/tests/unit/RandomIntTest.php
@@ -5,7 +5,7 @@ class RandomIntTest extends PHPUnit_Framework_TestCase
     {
         $this->assertTrue(function_exists('random_int'));
     }
-    
+
     public function testOutput()
     {
         $half_neg_max = (~PHP_INT_MAX / 2);
@@ -22,7 +22,7 @@ class RandomIntTest extends PHPUnit_Framework_TestCase
             random_int(-4.5, -4.5),
             random_int("1337e3","1337e3")
         );
-        
+
         $this->assertFalse($integers[0] === $integers[1]);
         $this->assertTrue($integers[0] >= 0 && $integers[0] <= 1000);
         $this->assertTrue($integers[1] >= 1001 && $integers[1] <= 2000);
@@ -35,7 +35,7 @@ class RandomIntTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($integers[8] >= 0 && $integers[8] <= 255);
         $this->assertSame($integers[9], -4);
         $this->assertSame($integers[10], 1337000);
-        
+
         try {
             $h = random_int("2147483648", "2147483647");
             $i = random_int("9223372036854775808", "9223372036854775807");

--- a/tests/unit/UtilityTest.php
+++ b/tests/unit/UtilityTest.php
@@ -10,7 +10,7 @@ class UtilityTest extends PHPUnit_Framework_TestCase
         }
         $this->assertEquals(RandomCompat_strlen("\xF0\x9D\x92\xB3"), 4);
     }
-    
+
     public function testIntval()
     {
         if (!function_exists('RandomCompat_intval')) {
@@ -23,7 +23,7 @@ class UtilityTest extends PHPUnit_Framework_TestCase
             abs(RandomCompat_intval(-4.5)),
             abs(RandomCompat_intval(4.5))
         );
-        
+
         // True
         $this->assertTrue(
             is_int(RandomCompat_intval(PHP_INT_MAX, true))
@@ -40,7 +40,7 @@ class UtilityTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(
             is_int(RandomCompat_intval("1.", true))
         );
-        
+
         // False
         $this->assertFalse(
             is_int(RandomCompat_intval((float) PHP_INT_MAX, true))
@@ -63,7 +63,7 @@ class UtilityTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(
             is_int(RandomCompat_intval("hello", true))
         );
-        
+
         if (PHP_INT_SIZE === 8) {
             $this->assertFalse(
                 is_int(RandomCompat_intval("-9223372036854775809", true))

--- a/tests/unit_with_basedir/RandomBytesTest.php
+++ b/tests/unit_with_basedir/RandomBytesTest.php
@@ -2,12 +2,12 @@
 class RandomBytesTest extends PHPUnit_Framework_TestCase
 {
     const NO_BASEDIR = 'There is no suitable CSPRNG installed on your system';
-    
+
     public function testFuncExists()
     {
         $this->assertTrue(function_exists('random_bytes'));
     }
-    
+
     public function testInvalidParams()
     {
         try {
@@ -23,7 +23,7 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
                 return;
             }
         }
-        
+
         try {
             $bytes = random_bytes(array(12));
             $this->fail("random_bytes() should accept only an integer");
@@ -34,7 +34,7 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
         } catch (Exception $ex) {
             $this->assertTrue(true);
         }
-        
+
         // This should succeed:
         try {
             $bytes = random_bytes('123456');
@@ -45,7 +45,7 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
             );
         }
     }
-    
+
     public function testOutput()
     {
         try {
@@ -62,19 +62,19 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
             );
             return;
         }
-        
+
         $this->assertTrue(
             strlen(bin2hex($bytes[0])) === 24
         );
         $this->assertTrue(
             strlen(bin2hex($bytes[3])) === 2
         );
-        
+
         // This should never generate identical byte strings
         $this->assertFalse(
             $bytes[1] === $bytes[2]
         );
-        
+
         try {
             $x = random_bytes(~PHP_INT_MAX - 1000000000);
             $this->fail("Integer overflow (~PHP_INT_MAX - 1000000000).");
@@ -85,7 +85,7 @@ class RandomBytesTest extends PHPUnit_Framework_TestCase
         } catch (Exception $ex) {
             $this->assertTrue(true);
         }
-        
+
         try {
             $x = random_bytes(PHP_INT_MAX + 1000000000);
             $this->fail("Requesting too many bytes should fail.");

--- a/tests/unit_with_basedir/RandomIntTest.php
+++ b/tests/unit_with_basedir/RandomIntTest.php
@@ -2,12 +2,12 @@
 class RandomIntTest extends PHPUnit_Framework_TestCase
 {
     const NO_BASEDIR = 'There is no suitable CSPRNG installed on your system';
-    
+
     public function testFuncExists()
     {
         $this->assertTrue(function_exists('random_int'));
     }
-    
+
     public function testOutput()
     {
         try {
@@ -46,7 +46,7 @@ class RandomIntTest extends PHPUnit_Framework_TestCase
             );
             return;
         }
-        
+
         try {
             $h = random_int("2147483648", "2147483647");
             $i = random_int("9223372036854775808", "9223372036854775807");

--- a/tests/unit_with_basedir/UtilityTest.php
+++ b/tests/unit_with_basedir/UtilityTest.php
@@ -10,7 +10,7 @@ class UtilityTest extends PHPUnit_Framework_TestCase
         }
         $this->assertEquals(RandomCompat_strlen("\xF0\x9D\x92\xB3"), 4);
     }
-    
+
     public function testIntval()
     {
         if (!function_exists('RandomCompat_intval')) {
@@ -23,7 +23,7 @@ class UtilityTest extends PHPUnit_Framework_TestCase
             abs(RandomCompat_intval(-4.5)),
             abs(RandomCompat_intval(4.5))
         );
-        
+
         // True
         $this->assertTrue(
             is_int(RandomCompat_intval(PHP_INT_MAX, true))
@@ -40,7 +40,7 @@ class UtilityTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(
             is_int(RandomCompat_intval("1.", true))
         );
-        
+
         // False
         $this->assertFalse(
             is_int(RandomCompat_intval((float) PHP_INT_MAX, true))
@@ -63,7 +63,7 @@ class UtilityTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(
             is_int(RandomCompat_intval("hello", true))
         );
-        
+
         if (PHP_INT_SIZE === 8) {
             $this->assertFalse(
                 is_int(RandomCompat_intval("-9223372036854775809", true))


### PR DESCRIPTION
# Changed log
- The `php-7.4` is stable. Using the `php-7.4` to replace the `php7.4snapshot`.
- Define PHPUnit version to support different PHP versions.
Using the `PHPUnit\Framework\TestCase` namespace.