### PR TITLE
GH Actions: version update for `ramsey/composer-install`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer self-update --1
 
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: PHPUnit tests
         run: vendor/bin/phpunit
@@ -58,11 +58,11 @@ jobs:
 
       - name: Install Composer dependencies (PHP < 8.1)
         if: ${{ matrix.php-versions != '8.1' }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
 
       - name: Install Composer dependencies - ignore-platform-reqs (PHP 8.1)
         if: ${{ matrix.php-versions == '8.1' }}
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -22,7 +22,7 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v1"
+        uses: "ramsey/composer-install@v2"
         with:
           composer-options: --no-dev
 


### PR DESCRIPTION
The action used to install Composer packages and handle the caching has released a new major (and some follow-up patch releases), which means, the action reference needs to be updated to benefit from it.

Refs:
* https://github.com/ramsey/composer-install/releases/tag/2.0.0
* https://github.com/ramsey/composer-install/releases/tag/2.0.1
* https://github.com/ramsey/composer-install/releases/tag/2.0.2
* https://github.com/ramsey/composer-install/releases/tag/2.0.3