### PR TITLE
GH Actions: run tests against PHP 8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
 
-    continue-on-error: ${{ matrix.php-versions == '8.1' }}
+    continue-on-error: ${{ matrix.php-versions == '8.2' }}
 
     steps:
       - name: Checkout
@@ -56,12 +56,12 @@ jobs:
       - name: Modernize dependencies
         run: composer require --dev --no-update "phpunit/phpunit:>=4"
 
-      - name: Install Composer dependencies (PHP < 8.1)
-        if: ${{ matrix.php-versions != '8.1' }}
+      - name: Install Composer dependencies (PHP < 8.2)
+        if: ${{ matrix.php-versions != '8.2' }}
         uses: "ramsey/composer-install@v2"
 
-      - name: Install Composer dependencies - ignore-platform-reqs (PHP 8.1)
-        if: ${{ matrix.php-versions == '8.1' }}
+      - name: Install Composer dependencies - ignore-platform-reqs (PHP 8.2)
+        if: ${{ matrix.php-versions == '8.2' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs


### PR DESCRIPTION
The first alpha of PHP 8.2 was released nearly two weeks ago, so let's start testing against PHP 8.2

Notes:
* Test runs again PHP 8.1 were still marked as "allowed to fail".
    This has been changed to allow PHP 8.2 to fail, but no longer allow failures for PHP 8.1.