### PR TITLE
GH Actions: update PHP versions in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
-    continue-on-error: ${{ matrix.php-versions == '8.2' }}
+    continue-on-error: ${{ matrix.php-versions == '8.4' }}
 
     steps:
       - name: Checkout
@@ -56,12 +56,12 @@ jobs:
       - name: Modernize dependencies
         run: composer require --dev --no-update "phpunit/phpunit:>=4"
 
-      - name: Install Composer dependencies (PHP < 8.2)
-        if: ${{ matrix.php-versions != '8.2' }}
+      - name: Install Composer dependencies (PHP < 8.4)
+        if: ${{ matrix.php-versions != '8.4' }}
         uses: "ramsey/composer-install@v2"
 
-      - name: Install Composer dependencies - ignore-platform-reqs (PHP 8.2)
-        if: ${{ matrix.php-versions == '8.2' }}
+      - name: Install Composer dependencies - ignore-platform-reqs (PHP 8.4)
+        if: ${{ matrix.php-versions == '8.4' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: --ignore-platform-reqs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         php-versions: ['5.3', '5.4', '5.5', '5.6', '7.0']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: composer self-update --1
 
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
 
       - name: PHPUnit tests
         run: vendor/bin/phpunit
@@ -58,11 +58,11 @@ jobs:
 
       - name: Install Composer dependencies (PHP < 8.4)
         if: ${{ matrix.php-versions != '8.4' }}
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
 
       - name: Install Composer dependencies - ignore-platform-reqs (PHP 8.4)
         if: ${{ matrix.php-versions == '8.4' }}
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           composer-options: --ignore-platform-reqs
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -22,7 +22,7 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v2"
+        uses: "ramsey/composer-install@v3"
         with:
           composer-options: --no-dev
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -12,7 +12,7 @@ jobs:
         php-versions: ['7.4']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
### GH Actions: update PHP versions in workflows

PHP 8.2 and 8.3 have been released quite a while ago and PHP 8.4 is expected towards end of November, so adding PHP 8.3 and 8.4 to the matrix and no longer allowing PHP 8.2 or 8.3 to fail the build.

Builds against PHP 8.4 are still allowed to fail for now.

### GH Actions: update the actions/checkout action runner

The v3 version still uses Node 16, while GHA will stop supporting that soonish. Using v4 fixes that.

### GH Actions: update the ramsey/composer-install action runner

The v2 version still uses Node 16, while GHA will stop supporting that soonish. Using v3 fixes that.